### PR TITLE
bugfix: リポジトリ名がブランクで検索した場合にHTTP 422エラーの対策

### DIFF
--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchScreen.kt
@@ -8,14 +8,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.leoleo.androidgithubsearch.R

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchViewModel.kt
@@ -24,6 +24,10 @@ class SearchViewModel @Inject constructor(
 
     fun searchRepositories(query: String, page: Int) {
         viewModelScope.launch(coroutineExceptionHandler) {
+            if (query.isEmpty()) {
+                uiState = SearchUiState.Error("Please input repository name")
+                return@launch
+            }
             uiState = SearchUiState.Loading
             val result = repository.searchRepositories(query, 1)
             uiState = if (result.isNotEmpty()) {


### PR DESCRIPTION
# issues (任意)
close https://github.com/LeoAndo/AndroidGithubSearch/issues/20

# 修正内容 (必須)
issue記載のバグを対応した。

# capture (任意)
<img src="https://user-images.githubusercontent.com/16476224/209351657-7a82fcb4-0591-4014-b3d8-9e40398757b9.png" width=320 />


# refs (任意)
https://developer.mozilla.org/ja/docs/Web/HTTP/Status/422