### PR TITLE
add themed icon

### DIFF
--- a/app/src/main/res/mipmap/ic_launcher.xml
+++ b/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background"/>
-    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background"/>
-    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
# issues (任意)
close #30

# 修正内容 (必須)
OS13の現時点のベータきのう Themed Iconを導入しました。

# capture (任意)

| before | after |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/209649804-33d32b08-386b-40df-8364-eff61503e807.png" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/209649809-12e2f458-5a85-4a94-8baf-4b4e558aaf89.png" width=320 /> |

# refs (任意)
https://www.youtube.com/watch?v=5fDc2XMf10A&t=3s