### PR TITLE
Responsive UI対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,4 +100,7 @@ dependencies {
 
     // Paging
     implementation "androidx.paging:paging-compose:1.0.0-alpha17"
+
+    // responsive UI for larger screens
+    implementation "androidx.compose.material3:material3-window-size-class:1.0.1"
 }

--- a/app/src/main/java/com/leoleo/androidgithubsearch/MainActivity.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/MainActivity.kt
@@ -3,15 +3,21 @@ package com.leoleo.androidgithubsearch
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.view.WindowCompat
 import com.leoleo.androidgithubsearch.ui.MainScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
-        setContent { MainScreen() }
+        setContent {
+            val windowSizeClass = calculateWindowSizeClass(this)
+            MainScreen(windowSizeClass.widthSizeClass)
+        }
     }
 }

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/MainScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/MainScreen.kt
@@ -1,94 +1,19 @@
 package com.leoleo.androidgithubsearch.ui
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
-import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
-import androidx.navigation.navigation
-import com.leoleo.androidgithubsearch.ui.GithubRepoSearchDestinations.DetailRoute.ARG_KEY_NAME
-import com.leoleo.androidgithubsearch.ui.GithubRepoSearchDestinations.DetailRoute.ARG_KEY_OWNER_NAME
-import com.leoleo.androidgithubsearch.ui.detail.DetailScreen
-import com.leoleo.androidgithubsearch.ui.search.SearchScreen
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import com.leoleo.androidgithubsearch.ui.compact.CompactMainScreen
+import com.leoleo.androidgithubsearch.ui.expanded.ExpandedMainScreen
+import com.leoleo.androidgithubsearch.ui.medium.MediumMainScreen
 import com.leoleo.androidgithubsearch.ui.theme.AndroidGithubSearchTheme
 
 @Composable
-fun MainScreen() {
+fun MainScreen(windowWidthSizeClass: WindowWidthSizeClass) {
     AndroidGithubSearchTheme {
-        Surface(
-            modifier = Modifier
-                .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.safeDrawing),
-            color = MaterialTheme.colorScheme.background
-        ) {
-            Box(modifier = Modifier.padding(12.dp)) {
-                MyNavHost(startDestination = TopDestinations.SearchRoute.routeName)
-            }
-        }
-    }
-}
-
-@Composable
-private fun MyNavHost(
-    modifier: Modifier = Modifier,
-    navController: NavHostController = rememberNavController(),
-    startDestination: String,
-) {
-    NavHost(
-        navController = navController,
-        startDestination = startDestination,
-        modifier = Modifier.fillMaxSize()
-    ) {
-        // nest navigation
-        navigation(
-            startDestination = GithubRepoSearchDestinations.TopRoute.routeName,
-            route = TopDestinations.SearchRoute.routeName,
-        ) {
-            composable(
-                route = GithubRepoSearchDestinations.TopRoute.routeName,
-                content = {
-                    SearchScreen(
-                        modifier = modifier,
-                        navigateToDetailScreen = { ownerName, name ->
-                            navController.navigate(
-                                GithubRepoSearchDestinations.DetailRoute.withArgs(
-                                    ownerName,
-                                    name,
-                                )
-                            )
-                        },
-                    )
-                }
-            )
-            composable(
-                route = GithubRepoSearchDestinations.DetailRoute.routeNameWithArgs,
-                arguments = listOf(
-                    navArgument(ARG_KEY_OWNER_NAME) {
-                        type = NavType.StringType
-                        nullable = false
-                    },
-                    navArgument(ARG_KEY_NAME) {
-                        type = NavType.StringType
-                        nullable = false
-                    },
-                ),
-                content = {
-                    val ownerName = it.arguments?.getString(ARG_KEY_OWNER_NAME) ?: return@composable
-                    val name = it.arguments?.getString(ARG_KEY_NAME) ?: return@composable
-                    DetailScreen(
-                        modifier = modifier,
-                        ownerName = ownerName,
-                        name = name,
-                    )
-                }
-            )
+        when (windowWidthSizeClass) {
+            WindowWidthSizeClass.Compact -> CompactMainScreen()
+            WindowWidthSizeClass.Medium -> MediumMainScreen()
+            WindowWidthSizeClass.Expanded -> ExpandedMainScreen()
         }
     }
 }

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/MyNavHost.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/MyNavHost.kt
@@ -1,0 +1,74 @@
+package com.leoleo.androidgithubsearch.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import androidx.navigation.navigation
+import com.leoleo.androidgithubsearch.ui.GithubRepoSearchDestinations.DetailRoute.ARG_KEY_NAME
+import com.leoleo.androidgithubsearch.ui.GithubRepoSearchDestinations.DetailRoute.ARG_KEY_OWNER_NAME
+import com.leoleo.androidgithubsearch.ui.detail.DetailScreen
+import com.leoleo.androidgithubsearch.ui.search.SearchScreen
+
+@Composable
+fun MyNavHost(
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+    startDestination: String,
+) {
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // nest navigation
+        navigation(
+            startDestination = GithubRepoSearchDestinations.TopRoute.routeName,
+            route = TopDestinations.SearchRoute.routeName,
+        ) {
+            composable(
+                route = GithubRepoSearchDestinations.TopRoute.routeName,
+                content = {
+                    SearchScreen(
+                        modifier = modifier,
+                        navigateToDetailScreen = { ownerName, name ->
+                            navController.navigate(
+                                GithubRepoSearchDestinations.DetailRoute.withArgs(
+                                    ownerName,
+                                    name,
+                                )
+                            )
+                        },
+                    )
+                }
+            )
+            composable(
+                route = GithubRepoSearchDestinations.DetailRoute.routeNameWithArgs,
+                arguments = listOf(
+                    navArgument(ARG_KEY_OWNER_NAME) {
+                        type = NavType.StringType
+                        nullable = false
+                    },
+                    navArgument(ARG_KEY_NAME) {
+                        type = NavType.StringType
+                        nullable = false
+                    },
+                ),
+                content = {
+                    val ownerName = it.arguments?.getString(ARG_KEY_OWNER_NAME) ?: return@composable
+                    val name = it.arguments?.getString(ARG_KEY_NAME) ?: return@composable
+                    DetailScreen(
+                        modifier = modifier,
+                        ownerName = ownerName,
+                        name = name,
+                    )
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/Page.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/Page.kt
@@ -1,0 +1,13 @@
+package com.leoleo.androidgithubsearch.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class Page(val label: String, val icon: ImageVector) {
+    HOME("Home", Icons.Filled.Home),
+    SEARCH("Search", Icons.Filled.Search),
+    User("User", Icons.Filled.Face)
+}

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/compact/CompactMainScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/compact/CompactMainScreen.kt
@@ -1,0 +1,27 @@
+package com.leoleo.androidgithubsearch.ui.compact
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.leoleo.androidgithubsearch.ui.MyNavHost
+import com.leoleo.androidgithubsearch.ui.TopDestinations
+
+@Composable
+fun CompactMainScreen() {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        MyNavHost(
+            startDestination = TopDestinations.SearchRoute.routeName,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/expanded/ExpandedMainScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/expanded/ExpandedMainScreen.kt
@@ -1,0 +1,216 @@
+package com.leoleo.androidgithubsearch.ui.expanded
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.leoleo.androidgithubsearch.R
+import com.leoleo.androidgithubsearch.ui.MyNavHost
+import com.leoleo.androidgithubsearch.ui.Page
+import com.leoleo.androidgithubsearch.ui.TopDestinations
+import com.leoleo.androidgithubsearch.ui.preview.PreviewFoldableDevice
+import com.leoleo.androidgithubsearch.ui.theme.AndroidGithubSearchTheme
+import com.leoleo.androidgithubsearch.ui.user.UserScreen
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpandedMainScreen() {
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    // icons to mimic drawer destinations
+    val items = Page.values()
+    var selectedItem by rememberSaveable { mutableStateOf(items[0]) }
+    val modifier = Modifier
+        .fillMaxSize()
+        .padding(16.dp)
+    ExpandedMainScreenStateless(
+        modifier = modifier,
+        drawerState = drawerState,
+        scope = scope,
+        selectedItem = selectedItem,
+        items = items,
+        onClickDrawerItem = { item -> selectedItem = item }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ExpandedMainScreenStateless(
+    modifier: Modifier,
+    drawerState: DrawerState,
+    scope: CoroutineScope,
+    selectedItem: Page,
+    items: Array<Page>,
+    onClickDrawerItem: (Page) -> Unit,
+) {
+    BackHandler(enabled = drawerState.isOpen) {
+        scope.launch {
+            drawerState.close()
+        }
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        DismissibleNavigationDrawer(
+            drawerState = drawerState,
+            drawerContent = {
+                DismissibleDrawerSheet {
+                    Spacer(Modifier.height(12.dp))
+                    items.forEach { item ->
+                        NavigationDrawerItem(
+                            icon = { Icon(item.icon, contentDescription = item.label) },
+                            label = { Text(item.label) },
+                            selected = item == selectedItem,
+                            onClick = {
+                                scope.launch { drawerState.close() }
+                                onClickDrawerItem(item)
+                            },
+                            modifier = Modifier.padding(horizontal = 12.dp)
+                        )
+                    }
+                }
+            },
+            content = {
+                when (Page.values().firstOrNull { it.ordinal == selectedItem.ordinal }) {
+                    Page.HOME -> {
+                        HomeScreen(modifier, drawerState, onClickDrawerControlBtn = {
+                            scope.launch {
+                                if (drawerState.isClosed) {
+                                    drawerState.open()
+                                } else {
+                                    drawerState.close()
+                                }
+                            }
+                        })
+                    }
+                    Page.SEARCH -> {
+                        MyNavHost(
+                            startDestination = TopDestinations.SearchRoute.routeName,
+                            modifier = modifier
+                        )
+                    }
+                    Page.User -> UserScreen(modifier)
+                    null -> Text(
+                        text = "$selectedItem is unknown.",
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .wrapContentSize()
+                    )
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HomeScreen(
+    modifier: Modifier,
+    drawerState: DrawerState,
+    onClickDrawerControlBtn: () -> Unit,
+) {
+    val buttonText = if (drawerState.isClosed) {
+        "Click to open"
+    } else {
+        "Click to close"
+    }
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(text = if (drawerState.isClosed) ">>> Swipe >>>" else "<<< Swipe <<<")
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { onClickDrawerControlBtn() }) {
+            Text(buttonText)
+        }
+        Text(text = stringResource(id = R.string.medium_screen_message))
+        Text(text = stringResource(id = R.string.medium_screen_message2))
+        Text(text = stringResource(id = R.string.medium_screen_message3))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewFoldableDevice
+@Composable
+private fun Prev_Open_Home_ExpandedMainScreen() {
+    AndroidGithubSearchTheme {
+        ExpandedMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            drawerState = rememberDrawerState(DrawerValue.Open),
+            scope = rememberCoroutineScope(),
+            selectedItem = Page.HOME,
+            items = Page.values(),
+            onClickDrawerItem = { }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewFoldableDevice
+@Composable
+private fun Prev_Open_Search_ExpandedMainScreen() {
+    AndroidGithubSearchTheme {
+        ExpandedMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            drawerState = rememberDrawerState(DrawerValue.Open),
+            scope = rememberCoroutineScope(),
+            selectedItem = Page.SEARCH,
+            items = Page.values(),
+            onClickDrawerItem = { }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewFoldableDevice
+@Composable
+private fun Prev_Open_User_ExpandedMainScreen() {
+    AndroidGithubSearchTheme {
+        ExpandedMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            drawerState = rememberDrawerState(DrawerValue.Open),
+            scope = rememberCoroutineScope(),
+            selectedItem = Page.User,
+            items = Page.values(),
+            onClickDrawerItem = { }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewFoldableDevice
+@Composable
+private fun Prev_Close_User_ExpandedMainScreen() {
+    AndroidGithubSearchTheme {
+        ExpandedMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            drawerState = rememberDrawerState(DrawerValue.Closed),
+            scope = rememberCoroutineScope(),
+            selectedItem = Page.User,
+            items = Page.values(),
+            onClickDrawerItem = { }
+        )
+    }
+}
+

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/medium/MediumMainScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/medium/MediumMainScreen.kt
@@ -1,0 +1,131 @@
+package com.leoleo.androidgithubsearch.ui.medium
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.leoleo.androidgithubsearch.R
+import com.leoleo.androidgithubsearch.ui.theme.AndroidGithubSearchTheme
+import com.leoleo.androidgithubsearch.ui.MyNavHost
+import com.leoleo.androidgithubsearch.ui.Page
+import com.leoleo.androidgithubsearch.ui.TopDestinations
+import com.leoleo.androidgithubsearch.ui.user.UserScreen
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.leoleo.androidgithubsearch.ui.preview.PreviewTabletDevice
+
+@Composable
+fun MediumMainScreen() {
+    val items = Page.values()
+    var selectedItem by rememberSaveable { mutableStateOf(items[0]) }
+    MediumMainScreenStateless(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(12.dp),
+        selectedItem = selectedItem,
+        onClickNavigationRailItem = { item ->
+            selectedItem = item
+        })
+}
+
+@Composable
+private fun MediumMainScreenStateless(
+    modifier: Modifier,
+    selectedItem: Page,
+    onClickNavigationRailItem: (Page) -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Row {
+            NavigationRail {
+                Page.values().forEachIndexed { _, item ->
+                    NavigationRailItem(
+                        icon = { Icon(item.icon, contentDescription = item.label) },
+                        label = { Text(item.label) },
+                        selected = selectedItem == item,
+                        onClick = { onClickNavigationRailItem(item) }
+                    )
+                }
+            }
+            when (Page.values().firstOrNull { it == selectedItem }) {
+                Page.HOME -> HomeScreen(modifier)
+                Page.SEARCH -> {
+                    MyNavHost(
+                        startDestination = TopDestinations.SearchRoute.routeName,
+                        modifier = modifier
+                    )
+                }
+                Page.User -> UserScreen(modifier)
+                null -> Text(
+                    text = "$selectedItem is unknown.",
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .wrapContentSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeScreen(modifier: Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Text(text = stringResource(id = R.string.medium_screen_message))
+        Text(text = stringResource(id = R.string.medium_screen_message2))
+        Text(text = stringResource(id = R.string.medium_screen_message3))
+    }
+}
+
+@PreviewTabletDevice
+@Composable
+private fun Prev_Home_MediumMainScreen() {
+    AndroidGithubSearchTheme {
+        MediumMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+            selectedItem = Page.HOME,
+            onClickNavigationRailItem = {},
+        )
+    }
+}
+
+@PreviewTabletDevice
+@Composable
+private fun Prev_Search_MediumMainScreen() {
+    AndroidGithubSearchTheme {
+        MediumMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+            selectedItem = Page.SEARCH,
+            onClickNavigationRailItem = {},
+        )
+    }
+}
+
+@PreviewTabletDevice
+@Composable
+private fun Prev_User_MediumMainScreen() {
+    AndroidGithubSearchTheme {
+        MediumMainScreenStateless(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+            selectedItem = Page.User,
+            onClickNavigationRailItem = {},
+        )
+    }
+}

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/user/UserScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/user/UserScreen.kt
@@ -1,0 +1,61 @@
+package com.leoleo.androidgithubsearch.ui.user
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.leoleo.androidgithubsearch.R
+import com.leoleo.androidgithubsearch.ui.theme.AndroidGithubSearchTheme
+import com.leoleo.androidgithubsearch.ui.preview.PreviewPhoneDevice
+import com.leoleo.androidgithubsearch.ui.util.AppLaunchHelper
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserScreen(modifier: Modifier) {
+    val items = listOf("Twitter", "Instagram", "Github")
+    val twitterUrl = stringResource(R.string.my_twitter_url)
+    val instagramUrl = stringResource(R.string.my_instagram_url)
+    val githubUrl = stringResource(R.string.my_github_url)
+    val appLaunchHelper = AppLaunchHelper(LocalContext.current)
+    LazyColumn(modifier = modifier) {
+        itemsIndexed(items) { _, data ->
+            Card(
+                modifier = Modifier
+                    .height(100.dp)
+                    .fillMaxWidth(),
+                onClick = {
+                    when (data) {
+                        "Twitter" -> appLaunchHelper.launchBrowserApp(twitterUrl)
+                        "Instagram" -> appLaunchHelper.launchBrowserApp(instagramUrl)
+                        "Github" -> appLaunchHelper.launchBrowserApp(githubUrl)
+                    }
+                },
+            ) {
+                Text(
+                    text = data, modifier = Modifier
+                        .fillMaxSize()
+                        .wrapContentSize()
+                )
+            }
+            Spacer(modifier = Modifier.size(20.dp))
+        }
+    }
+}
+
+@PreviewPhoneDevice
+@Composable
+private fun Prev_UserScreen() {
+    AndroidGithubSearchTheme {
+        AppLaunchHelper(LocalContext.current).launchInstagramApp("sas")
+        UserScreen(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/util/AppLaunchHelper.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/util/AppLaunchHelper.kt
@@ -1,0 +1,108 @@
+package com.leoleo.androidgithubsearch.ui.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.net.Uri
+import android.widget.Toast
+
+class AppLaunchHelper constructor(private val context: Context) {
+    fun launchMapApp(latitude: Double, longitude: Double, query: String) {
+        launchExternalApp(onAction = {
+            val uri = Uri.parse("geo:$latitude,$longitude?q=$query")
+            Intent(Intent.ACTION_VIEW, uri).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.let {
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    fun launchTelApp(tel: String) {
+        launchExternalApp(onAction = {
+            val uri = Uri.parse("tel:$tel")
+            Intent(Intent.ACTION_DIAL, uri).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.let {
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    fun launchMailApp(address: String, subject: String, text: String) {
+        launchExternalApp(onAction = {
+            Intent(Intent.ACTION_SENDTO).apply {
+                data = Uri.parse("mailto:")
+                putExtra(Intent.EXTRA_EMAIL, arrayOf(address))
+                putExtra(Intent.EXTRA_SUBJECT, subject)
+                putExtra(Intent.EXTRA_TEXT, text)
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.let {
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    fun launchInstagramApp(url: String) {
+        launchExternalApp(onAction = {
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.also {
+                it.setPackage("com.instagram.android")
+                it.data = Uri.parse(url)
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    fun launchTwitterApp(url: String) {
+        launchExternalApp(onAction = {
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.also {
+                it.setPackage("com.twitter.android")
+                it.data = Uri.parse(url)
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    fun launchFacebookApp(url: String) {
+        launchExternalApp(onAction = {
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.also {
+                it.setPackage("com.facebook.katana")
+                it.data = Uri.parse("fb://facewebmodal/f?href=$url")
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    fun launchBrowserApp(url: String) {
+        launchExternalApp(onAction = {
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+            }.let {
+                context.startActivity(it)
+            }
+        }, onErrorAction = { showToast(it) })
+    }
+
+    private fun launchExternalApp(onAction: () -> Unit, onErrorAction: (String) -> Unit) {
+        kotlin.runCatching {
+            onAction.invoke()
+        }.onFailure {
+            when (it) {
+                is ActivityNotFoundException -> {
+                    onErrorAction(it.localizedMessage ?: "launch app error.")
+                }
+            }
+        }
+    }
+
+    private fun showToast(message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,11 @@
     <string name="open_issues_count">%s Issue</string>
     <string name="subscribers_count">%s Watcher</string>
     <string name="language">language: %s</string>
+    <string name="medium_screen_message">This is Home Screen.</string>
+    <string name="medium_screen_message2">If you want to use the search function of the github repository, tap the Search icon.</string>
+    <string name="medium_screen_message3">If you want to know the developer\'s information, please tap the Face icon.</string>
+    <string name="my_twitter_url">https://twitter.com/Leo99490411Leo</string>
+    <string name="my_instagram_url">https://www.instagram.com/leo.ando100/</string>
+    <string name="my_github_url">https://github.com/LeoAndo</string>
+
 </resources>


### PR DESCRIPTION
# issues (任意)
close https://github.com/LeoAndo/AndroidGithubSearch/issues/19

# 修正内容 (必須)
Responsive UI対応を行いました。
Activityで`WindowWidthSizeClass`を判定し、エントリポイントとなる画面(Composable)をタイプ別に用意しました。

# refs (任意)
https://github.com/LeoAndo/development-conference-memo/issues?q=is%3Aissue+is%3Aopen+large+
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/samples/src/main/java/androidx/compose/material3/samples/NavigationRailSamples.kt
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/samples/src/main/java/androidx/compose/material3/samples/DrawerSamples.kt
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/samples/src/main/java/androidx/compose/material3/samples/
https://developer.android.com/reference/kotlin/androidx/compose/material3/windowsizeclass/WindowSizeClass
https://developer.android.com/reference/kotlin/androidx/compose/material3/windowsizeclass/package-summary

# capture (Compact)

<img src="https://user-images.githubusercontent.com/16476224/209670631-674f63f8-9f68-4611-898f-75658850a7e6.png" />

# capture (Medium)

<img src="https://user-images.githubusercontent.com/16476224/209670680-ac5a11f4-edfa-401c-abc3-6b51d1d70677.png" />

# capture (Expanded)

<img src="https://user-images.githubusercontent.com/16476224/209670842-5e7ef8c4-1e47-4f63-a6e7-46712418d9c1.png" />