### PR TITLE
通信エラーなどの異常発生時に適切なメッセージをユーザに伝える

### DIFF
--- a/app/src/main/java/com/leoleo/androidgithubsearch/data/SafeResult.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/data/SafeResult.kt
@@ -15,20 +15,12 @@ sealed class SafeResult<out R> {
 }
 
 sealed class ErrorResult : Exception() {
-    data class UnAuthorizedError(override val message: String? = "UnAuthorizedError") :
-        ErrorResult()
-
-    data class BadRequestError(override val message: String? = "BadRequestError") :
-        ErrorResult()
-
-    data class NotFoundError(override val message: String? = "NotFoundError") :
-        ErrorResult()
-
-    data class NetworkError(override val message: String? = "NetworkError") :
-        ErrorResult()
-
-    data class UnexpectedError(override val message: String? = "UnexpectedError") :
-        ErrorResult()
+    data class UnAuthorizedError(override val message: String) : ErrorResult()
+    data class BadRequestError(override val message: String) : ErrorResult()
+    data class NotFoundError(override val message: String) : ErrorResult()
+    data class ForbiddenError(override val message: String) : ErrorResult()
+    data class NetworkError(override val message: String) : ErrorResult()
+    data class UnexpectedError(override val message: String) : ErrorResult()
 }
 
 suspend fun <T> dataOrThrow(
@@ -55,27 +47,34 @@ private suspend fun <T> safeCall(
                 is HttpException -> {
                     when (e.code()) {
                         HttpURLConnection.HTTP_UNAUTHORIZED -> SafeResult.Error(
-                            ErrorResult.UnAuthorizedError(
-                                e.localizedMessage
-                            )
+                            ErrorResult.UnAuthorizedError(e.localizedMessage ?: "UnAuthorizedError")
                         )
                         HttpURLConnection.HTTP_BAD_REQUEST -> SafeResult.Error(
-                            ErrorResult.BadRequestError(
-                                e.localizedMessage
-                            )
+                            ErrorResult.BadRequestError(e.localizedMessage ?: "BadRequestError")
                         )
                         HttpURLConnection.HTTP_NOT_FOUND -> SafeResult.Error(
-                            ErrorResult.NotFoundError(
-                                e.localizedMessage
-                            )
+                            ErrorResult.NotFoundError(e.localizedMessage ?: "NotFoundError")
                         )
-                        else -> SafeResult.Error(ErrorResult.UnexpectedError(e.localizedMessage))
+                        HttpURLConnection.HTTP_FORBIDDEN -> SafeResult.Error(
+                            ErrorResult.ForbiddenError(e.localizedMessage ?: "ForbiddenError")
+                        )
+                        else -> {
+                            SafeResult.Error(
+                                ErrorResult.UnexpectedError(e.localizedMessage ?: "UnexpectedError")
+                            )
+                        }
                     }
                 }
                 is UnknownHostException, is ConnectException, is SocketTimeoutException -> {
-                    SafeResult.Error(ErrorResult.NetworkError(e.localizedMessage))
+                    SafeResult.Error(ErrorResult.NetworkError(e.localizedMessage ?: "NetworkError"))
                 }
-                else -> SafeResult.Error(ErrorResult.UnexpectedError(e.localizedMessage))
+                else -> {
+                    SafeResult.Error(
+                        ErrorResult.UnexpectedError(
+                            e.localizedMessage ?: "UnexpectedError"
+                        )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/detail/DetailScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/detail/DetailScreen.kt
@@ -44,31 +44,24 @@ private fun DetailScreenStateless(
         UiState.Loading -> LoadingFullScreen()
         is UiState.Error -> {
             val throwable = uiState.throwable
-            val message =
-                throwable.localizedMessage ?: stringResource(id = R.string.default_error_message)
-            if (throwable is ErrorResult) {
+            val message = if (throwable is ErrorResult) {
                 when (throwable) {
-                    is ErrorResult.NotFoundError -> {
-                        ErrorFullScreen(message = message, onReload = { onReload() })
-                        AppAlertDialog(
-                            titleText = message,
-                            messageText = stringResource(id = R.string.page_not_found_message),
-                            confirmText = stringResource(id = android.R.string.ok),
-                        )
-                    }
-                    is ErrorResult.ForbiddenError -> {
-                        ErrorFullScreen(
-                            message = stringResource(id = R.string.forbidden_error_message),
-                            onReload = { onReload() })
-                    }
-                    is ErrorResult.BadRequestError, is ErrorResult.NetworkError, is ErrorResult.UnAuthorizedError,
-                    is ErrorResult.UnexpectedError -> {
-                        ErrorFullScreen(message = message, onReload = { onReload() })
+                    is ErrorResult.NetworkError -> stringResource(id = R.string.network_error_message)
+                    is ErrorResult.NotFoundError -> stringResource(id = R.string.page_not_found_message)
+                    is ErrorResult.BadRequestError, is ErrorResult.UnexpectedError,
+                    is ErrorResult.ForbiddenError, is ErrorResult.UnAuthorizedError -> {
+                        throwable.message ?: stringResource(id = R.string.default_error_message)
                     }
                 }
             } else {
-                ErrorFullScreen(message = message, onReload = { onReload() })
+                throwable.localizedMessage ?: stringResource(id = R.string.default_error_message)
             }
+            ErrorFullScreen(message = message, onReload = onReload)
+            AppAlertDialog(
+                titleText = stringResource(id = R.string.app_name),
+                messageText = message,
+                confirmText = stringResource(id = android.R.string.ok),
+            )
         }
         is UiState.Data -> {
             Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(20.dp)) {

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/detail/DetailScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/detail/DetailScreen.kt
@@ -56,6 +56,11 @@ private fun DetailScreenStateless(
                             confirmText = stringResource(id = android.R.string.ok),
                         )
                     }
+                    is ErrorResult.ForbiddenError -> {
+                        ErrorFullScreen(
+                            message = stringResource(id = R.string.forbidden_error_message),
+                            onReload = { onReload() })
+                    }
                     is ErrorResult.BadRequestError, is ErrorResult.NetworkError, is ErrorResult.UnAuthorizedError,
                     is ErrorResult.UnexpectedError -> {
                         ErrorFullScreen(message = message, onReload = { onReload() })

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchScreen.kt
@@ -150,11 +150,11 @@ private fun LazyListScope.errorContent(
         val message = if (throwable is ErrorResult) {
             when (throwable) {
                 is ErrorResult.UnAuthorizedError -> stringResource(id = R.string.unauthorized_message)
-                is ErrorResult.BadRequestError, is ErrorResult.NetworkError, is ErrorResult.NotFoundError,
-                is ErrorResult.UnexpectedError -> {
+                is ErrorResult.ForbiddenError -> stringResource(id = R.string.forbidden_error_message)
+                is ErrorResult.NetworkError -> stringResource(id = R.string.network_error_message)
+                is ErrorResult.BadRequestError, is ErrorResult.NotFoundError, is ErrorResult.UnexpectedError -> {
                     throwable.message ?: stringResource(id = R.string.default_error_message)
                 }
-                is ErrorResult.ForbiddenError -> stringResource(id = R.string.forbidden_error_message)
             }
         } else {
             throwable.localizedMessage ?: stringResource(id = R.string.default_error_message)

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/search/SearchScreen.kt
@@ -154,6 +154,7 @@ private fun LazyListScope.errorContent(
                 is ErrorResult.UnexpectedError -> {
                     throwable.message ?: stringResource(id = R.string.default_error_message)
                 }
+                is ErrorResult.ForbiddenError -> stringResource(id = R.string.forbidden_error_message)
             }
         } else {
             throwable.localizedMessage ?: stringResource(id = R.string.default_error_message)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,5 +23,6 @@
     <string name="test_tag_medium_main_screen">test_tag_compact_medium_screen</string>
     <string name="test_tag_expanded_main_screen">test_tag_expanded_main_screen</string>
     <string name="test_tag_search_screen">test_tag_search_screen</string>
+    <string name="forbidden_error_message">API rate limit exceeded. Please try again later.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,5 +24,6 @@
     <string name="test_tag_expanded_main_screen">test_tag_expanded_main_screen</string>
     <string name="test_tag_search_screen">test_tag_search_screen</string>
     <string name="forbidden_error_message">API rate limit exceeded. Please try again later.</string>
+    <string name="network_error_message">Please check the network status.</string>
 
 </resources>


### PR DESCRIPTION
# issues (任意)
なし

# 修正内容 (必須)
通信エラーなどの異常発生時に意適切なメッセージをユーザに伝えるように修正しました。

# capture : HTTP_FORBIDDEN
<img src="https://user-images.githubusercontent.com/16476224/209836669-4d934cc9-34f3-4ba8-a6ca-b5d65d39f9ae.png" width=320 />

# capture : 通信エラー
<img src="https://user-images.githubusercontent.com/16476224/209836848-024ce0dc-4631-4387-979b-94e2bf41c45f.gif" width=320 />

# refs (任意)
https://docs.github.com/ja/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting