### PR TITLE
Gradleやライブラリを更新する

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,8 @@ android {
         compose true
     }
     composeOptions {
+        // Kotlin Versionとの互換性マップ
+        // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
         kotlinCompilerExtensionVersion '1.3.2'
     }
     packagingOptions {
@@ -74,19 +76,22 @@ dependencies {
     implementation project(':domain')
     implementation project(':data') // DIで必要
 
-    def compose_version = '1.3.2'
+    // compose Bomを利用
+    def compose_version = platform('androidx.compose:compose-bom:2023.01.00')
+    implementation compose_version
+    androidTestImplementation compose_version
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation 'androidx.activity:activity-compose:1.6.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.1.0-alpha03'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
     testImplementation("junit:junit:$junit_version")
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_test_version")
 
     // DI
@@ -107,5 +112,5 @@ dependencies {
     implementation "androidx.paging:paging-compose:1.0.0-alpha17"
 
     // responsive UI for larger screens
-    implementation "androidx.compose.material3:material3-window-size-class:1.0.1"
+    implementation 'androidx.compose.material3:material3-window-size-class'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,8 +87,8 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     testImplementation("junit:junit:$junit_version")
-    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     implementation "androidx.navigation:navigation-compose:2.5.3"
 
     // Image
-    implementation "io.coil-kt:coil-compose:1.3.2"
+    implementation "io.coil-kt:coil-compose:2.2.2"
 
     // Paging
     implementation "androidx.paging:paging-compose:1.0.0-alpha17"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
     composeOptions {
         // Kotlin Versionとの互換性マップ
         // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.4.2'
     }
     packagingOptions {
         resources {
@@ -109,7 +109,7 @@ dependencies {
     implementation "io.coil-kt:coil-compose:2.2.2"
 
     // Paging
-    implementation "androidx.paging:paging-compose:1.0.0-alpha17"
+    implementation "androidx.paging:paging-compose:1.0.0-alpha18"
 
     // responsive UI for larger screens
     implementation 'androidx.compose.material3:material3-window-size-class'

--- a/app/src/main/java/com/leoleo/androidgithubsearch/ui/component/NetworkImage.kt
+++ b/app/src/main/java/com/leoleo/androidgithubsearch/ui/component/NetworkImage.kt
@@ -9,16 +9,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import coil.annotation.ExperimentalCoilApi
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import coil.transform.Transformation
 import com.leoleo.androidgithubsearch.R
 import com.leoleo.androidgithubsearch.ui.preview.PreviewPhoneDevice
 
-@OptIn(ExperimentalCoilApi::class)
 @Composable
 fun AppNetworkImage(
     modifier: Modifier = Modifier,
@@ -27,15 +27,15 @@ fun AppNetworkImage(
     transformations: List<Transformation> = emptyList(),
 ) {
     Image(
-        painter = rememberImagePainter(
-            data = imageUrl,
-            builder = {
-                crossfade(true)
-                placeholder(drawableResId = R.drawable.placeholder_image)
-                error(drawableResId = R.drawable.error_image)
-                fallback(drawableResId = R.drawable.fallback_image)
-                transformations(transformations)
-            }
+        painter = rememberAsyncImagePainter(
+            ImageRequest.Builder(LocalContext.current).data(data = imageUrl)
+                .apply(block = fun ImageRequest.Builder.() {
+                    crossfade(true)
+                    placeholder(drawableResId = R.drawable.placeholder_image)
+                    error(drawableResId = R.drawable.error_image)
+                    fallback(drawableResId = R.drawable.fallback_image)
+                    transformations(transformations)
+                }).build()
         ),
         contentDescription = contentDescription,
         modifier = modifier,

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.1' apply false
+    id 'com.android.library' version '7.4.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.20' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.7.20' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        dagger_hilt_version = '2.44.2'
+        dagger_hilt_version = '2.45'
         paging_common_version = '3.1.1' // androidx.paging:paging-compose内部で使っているversionを指定
         junit_version = '4.13.2'
         coroutines_test_version = '1.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '7.4.1' apply false
     id 'com.android.library' version '7.4.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.20' apply false
-    id 'org.jetbrains.kotlin.jvm' version '1.7.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.10' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.8.10' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         dagger_hilt_version = '2.45'
         paging_common_version = '3.1.1' // androidx.paging:paging-compose内部で使っているversionを指定
         junit_version = '4.13.2'
-        coroutines_test_version = '1.5.2'
+        coroutines_test_version = '1.6.4'
     }
     dependencies {
         classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger_hilt_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Dec 17 13:46:19 JST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# issues (任意)
close #81

# 修正内容 (必須)
- [gradle: 7.3.1 -> 7.4.1](https://docs.gradle.org/7.4.1/release-notes.html)
- [dagger 2.45](https://github.com/google/dagger/releases/tag/dagger-2.45)
- UnitTest周りのライブラリ
- [compose周りのライブラリをBOMに移行](https://developer.android.com/jetpack/compose/bom/bom-mapping?hl=ja)
- [coil 2.22](https://github.com/coil-kt/coil/releases/tag/2.2.2)にアップデート
- [paging 1.0.0-alpha18](https://developer.android.com/jetpack/androidx/releases/paging?hl=ja#1.0.0-alpha18)
  - 1.0.0-alpha18からKotlin 1.8に依存する 

ライブラリの更新は基本的にProduct Structureから行った。
<img width="282" alt="スクリーンショット 2023-02-19 21 34 27" src="https://user-images.githubusercontent.com/16476224/219950960-be1dd9fc-7fdb-41a1-8ab7-472749017a3f.png">

# capture (任意)

| before | after |
|:---|:---:|
|<img src="" width=320 /> |<img src="" width=320 /> |

# refs (任意)